### PR TITLE
fix: 修复编译目标版本过低导致的运行错误

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "es6",
     "outDir": "out",
     "lib": ["ES2020.Promise"],
     "sourceMap": true,


### PR DESCRIPTION
可能是因为我用的是开发版本的 Vscode，不知道何时开始出现这个报错 `Class constructor Ke cannot be invoked without 'new'`

![image](https://user-images.githubusercontent.com/7511631/178549164-55d94bcc-b743-423b-ae3b-cef2d91019d5.png)

The "Class constructor cannot be invoked without new" error occurs when the target property in tsconfig.json is set to lower than es6 or you instantiate a class without the new operator. To solve the error, set the target to es6 and use the new operator when instantiating classes.

能够运行插件的环境应该都支持 es6 语法，所以问题不大。

运行结果截图：

![image](https://user-images.githubusercontent.com/7511631/178549648-062d3e29-fcde-4dc7-952f-78a07ca32290.png)

