### PR TITLE
fix: issue#399当日收益计算字段更换

### DIFF
--- a/src/statusbar/Profit.ts
+++ b/src/statusbar/Profit.ts
@@ -126,7 +126,7 @@ export class ProfitStatusBar {
       stockList.forEach((s) => {
         let tmp = {} as StockInfoType;
         const { id, info } = s;
-        const { high, low, open, percent, price, name } = info;
+        const { high, low, open, yestclose, percent, price, name } = info;
         if (id && open && price) {
           const config = stockPrice[id];
           if (!config || config.amount === 0 || config.unitPrice === 0) {
@@ -137,7 +137,8 @@ export class ProfitStatusBar {
           // const incomeTotal = amount * (Number(price).toFixed(2) - unitPrice.toFixed(2));
           // const incomeToday = amount * (Number(price).toFixed(2) - Number(open).toFixed(2));
           const incomeTotal = (amount * (Number(price) - unitPrice)).toFixed(2);
-          const incomeToday = (amount * (Number(price) - Number(open))).toFixed(2);
+          // fix #399，在昨日收盘价没有的时候使用今日开盘价
+          const incomeToday = (amount * (Number(price) - Number(yestclose || open))).toFixed(2);
           const percentTotal = ((Number(incomeTotal) / (unitPrice * amount)) * 100).toFixed(2);
           tmp = {
             id,


### PR DESCRIPTION
之前当前计算公式为：price(当前价格)-open(今日开盘价)
提交替换为为price(当前价格)-yestclose(昨日封盘价格),如无yestclose，还是使用open
