### PR TITLE
更新币安api，优化请求次数

### DIFF
--- a/src/explorer/binanceService.ts
+++ b/src/explorer/binanceService.ts
@@ -15,8 +15,8 @@ import { LeekService } from './leekService';
 
 export default class BinanceService extends LeekService {
   private context: ExtensionContext;
-  private parisUrl = 'https://api.binance.com/api/v1/exchangeInfo';
-  private ticker24hrUrl = 'https://api.binance.com/api/v1/ticker/24hr';
+  private parisUrl = 'https://data-api.binance.vision/api/v3/exchangeInfo';
+  private ticker24hrUrl = 'https://data-api.binance.vision/api/v3/ticker/24hr';
   constructor(context: ExtensionContext) {
     super();
     this.context = context;
@@ -38,26 +38,33 @@ export default class BinanceService extends LeekService {
     return [''];
   }
 
-  async _fetchPairData(symbolWithSplit: string): Promise<any> {
-    const symbol = symbolWithSplit.split('_').join('');
-    return {
-      data: await Axios.get(this.ticker24hrUrl, {
-        params: { symbol },
-        headers: randHeader(),
-      }).catch((err) => {
-        globalState.telemetry.sendEvent('error: binanceService', {
-          url: this.ticker24hrUrl,
-          error: err,
-        });
-      }),
-      symbol: symbolWithSplit,
-    };
+  async _fetchPairData(symbolsWithSplit: string[]): Promise<{ data: any, symbol: string }[]> {
+    const symbols = JSON.stringify(symbolsWithSplit.map(sws => sws.split('_').join('')));
+    return await Axios.get<{ data: any[] }>(this.ticker24hrUrl, {
+      params: { symbols },
+      headers: randHeader(),
+    }).then(res => symbolsWithSplit.map(symbol => {
+      const target = (res.data as any).find((data: any) => data.symbol === symbol.split('_').join(''))
+      return ({ data: target, symbol });
+    })).catch((err) => {
+      globalState.telemetry.sendEvent('error: binanceService', {
+        url: this.ticker24hrUrl,
+        error: err,
+      });
+      return Promise.reject(symbolsWithSplit.map(symbol => ({ data: null, symbol })));
+    });
   }
 
   async getData(codes: string[]): Promise<LeekTreeItem[]> {
     const pairList: Array<LeekTreeItem> = [];
 
-    const promises = codes.map((i) => this._fetchPairData(i));
+    // 20个请求的权重最低
+    let splitFetch = [];
+    while (codes.length > 20) {
+      splitFetch.push(codes.splice(0, 20));
+    }
+    splitFetch.push(codes);
+    const promises = splitFetch.map(splitCodes => this._fetchPairData(splitCodes));
     /* Shim for Promise.allSettled */
     if (!Promise.allSettled) {
       // @ts-ignore
@@ -71,48 +78,50 @@ export default class BinanceService extends LeekService {
         return Promise.all(wrappedPromises);
       };
     }
-    // @ts-ignore
-    const results = await Promise.allSettled(promises);
-    // console.log('results=', results);
 
-    for (const item of results) {
+    const results = await Promise.allSettled(promises);
+    // console.log(results, 'results')
+    for (const splitRes of results) {
       // @ts-ignore
-      const { status, value = {} } = item || {};
-      if (status === 'fulfilled' && value.data) {
-        const {
-          data: { data },
-          symbol,
-        } = value;
-        const obj: FundInfo = {
-          id: symbol,
-          code: '',
-          name: symbol,
-          price: data.lastPrice, // 现价
-          open: data.openPrice, // 今开
-          yestclose: data.prevClosePrice, // 昨收
-          volume: data.volume, // 24h成交量
-          amount: data.quoteVolume, // 24h成交额
-          percent: data.priceChangePercent, // 百分比
-          updown: data.priceChange, // 涨跌
-          high: data.highPrice, // 最高
-          low: data.lowPrice, // 最低
-          showLabel: this.showLabel,
-          _itemType: TreeItemType.BINANCE,
-        };
-        pairList.push(new LeekTreeItem(obj, this.context));
-      } else {
-        // handle status === 'rejected'
-        const { symbol } = value;
-        const obj: FundInfo = {
-          id: symbol,
-          code: '',
-          percent: '0',
-          name: symbol + '网络错误',
-          showLabel: this.showLabel,
-          _itemType: TreeItemType.BINANCE,
-        };
-        pairList.push(new LeekTreeItem(obj, this.context));
+      const { status, value, reason } = splitRes;
+      for (const item of (value || reason)) {
+        if (status === 'fulfilled') {
+          const {
+            data,
+            symbol,
+          } = item;
+          const obj: FundInfo = {
+            id: symbol,
+            code: '',
+            name: symbol,
+            price: data.lastPrice, // 现价
+            open: data.openPrice, // 今开
+            yestclose: data.prevClosePrice, // 昨收
+            volume: data.volume, // 24h成交量
+            amount: data.quoteVolume, // 24h成交额
+            percent: data.priceChangePercent, // 百分比
+            updown: data.priceChange, // 涨跌
+            high: data.highPrice, // 最高
+            low: data.lowPrice, // 最低
+            showLabel: this.showLabel,
+            _itemType: TreeItemType.BINANCE,
+          };
+          pairList.push(new LeekTreeItem(obj, this.context));
+        } else {
+          // handle status === 'rejected'
+          const { symbol } = item;
+          const obj: FundInfo = {
+            id: symbol,
+            code: '',
+            percent: '0',
+            name: symbol + '网络错误',
+            showLabel: this.showLabel,
+            _itemType: TreeItemType.BINANCE,
+          };
+          pairList.push(new LeekTreeItem(obj, this.context));
+        }
       }
+
     }
     return pairList;
   }


### PR DESCRIPTION
v1的请求太容易挂了，切换成v3，使用最少20个的交易对请求，减少请求权重