### PR TITLE
feat: 状态栏增加美股和港股的盈亏显示

### DIFF
--- a/src/explorer/stockService.ts
+++ b/src/explorer/stockService.ts
@@ -205,6 +205,13 @@ export default class StockService extends LeekService {
               let high = params[6];
               let low = params[7];
               fixedNumber = calcFixedPriceNumber(open, yestclose, price, high, low);
+              const profitData = stockPrice[code] || {};
+              const heldData: HeldData = {};
+              if (profitData.amount) {
+                // 表示是持仓股
+                heldData.heldAmount = profitData.amount;
+                heldData.heldPrice = profitData.unitPrice;
+              }
               stockItem = {
                 code,
                 name: params[0],
@@ -216,6 +223,7 @@ export default class StockService extends LeekService {
                 volume: formatNumber(params[10], 2),
                 amount: '接口无数据',
                 percent: '',
+                ...heldData
               };
               type = code.substr(0, 4);
               usStockCount += 1;
@@ -412,9 +420,25 @@ export default class StockService extends LeekService {
         return [];
       } else {
         const stocks = stockData;
+        const stockPrice: {
+          [key: string]: {
+            amount: number;
+            earnings: number;
+            name: string;
+            price: string;
+            unitPrice: number;
+          };
+        } = globalState.stockPrice;
         stocks.forEach((item: any) => {
-          const { open, yestclose, price, high, low, volume, amount, time } = item;
+          const { open, yestclose, price, high, low, volume, amount, time, code } = item;
           const fixedNumber = calcFixedPriceNumber(open, yestclose, price, high, low);
+          const profitData = stockPrice[code] || {};
+          const heldData: HeldData = {};
+          if (profitData.amount) {
+            // 表示是持仓股
+            heldData.heldAmount = profitData.amount;
+            heldData.heldPrice = profitData.unitPrice;
+          }
           const stockItem: any = {
             ...item,
             open: formatNumber(open, fixedNumber, false),
@@ -426,6 +450,7 @@ export default class StockService extends LeekService {
             amount: formatNumber(amount || 0, 2),
             percent: '',
             time: `${moment(time).format('YYYY-MM-DD HH:mm:ss')}`,
+            ...heldData,
           };
           hkStockCount += 1;
           if (stockItem) {

--- a/src/globalState.ts
+++ b/src/globalState.ts
@@ -1,6 +1,7 @@
 import { ExtensionContext } from 'vscode';
 import { DEFAULT_LABEL_FORMAT } from './shared/constant';
 import { Telemetry } from './shared/telemetry';
+import { ForexData } from './shared/typed';
 
 const deviceId = Math.random().toString(16).substr(2) + Math.random().toString(32).substr(2);
 
@@ -40,6 +41,8 @@ let fundLists: Array<Array<string>> = [];
 
 let stockPrice = {}; // 缓存数据
 let stockPriceCacheDate = '2020-10-30';
+
+let forexList: Array<ForexData> = []; // 外汇信息
 export default {
   context,
   telemetry,
@@ -74,4 +77,6 @@ export default {
   stockPriceCacheDate,
 
   stockHeldTipShow,
+
+  forexList
 };

--- a/src/shared/typed.ts
+++ b/src/shared/typed.ts
@@ -112,3 +112,15 @@ export type HeldData = {
   heldAmount?: number;
   heldPrice?: number;
 };
+
+export type ForexData = {
+  name: string;
+  filter: ((code: string) => boolean) | RegExp;
+  spotBuyPrice?: number; // 现汇买入价
+  cashBuyPrice?: number; // 现钞买入价
+  spotSellPrice?: number; // 现汇卖出价
+  cashSellPrice?: number; // 现钞卖出价
+  conversionPrice?: number; // 中行折算价
+  publishDateTime?: string; // 发布日期：年月日 时分秒
+  publishTime?: string; // 发布时间：时分秒
+};

--- a/src/statusbar/Profit.ts
+++ b/src/statusbar/Profit.ts
@@ -146,7 +146,7 @@ export class ProfitStatusBar {
 
           if (forex) {
             if (forex.spotSellPrice) {
-              // 按折算价算汇率
+              // 按现汇卖出价计算
               incomeTodayCNY = (forex.spotSellPrice * Number(incomeToday) / 100).toFixed(2);
               incomeTotalCNY = (forex.spotSellPrice * Number(incomeTotal) / 100).toFixed(2);
             }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/372c403b-9e70-4016-b271-4022f71827d1)

菜单开启 Foxer 后，

- 计算总盈亏时会先转化为人民币，再做计算
- tooltip 会同时展示对应币种的盈亏以及转换为人民币的盈亏