### PR TITLE
fix: 修复导航栏浅色主题颜色固定的问题

### DIFF
--- a/template-packages/leek-center/src/components/layout/Header.module.less
+++ b/template-packages/leek-center/src/components/layout/Header.module.less
@@ -4,7 +4,7 @@
   margin-top: 4px;
   font-size: 18px;
   line-height: 42px;
-  color: #fff;
+  // color: #fff;
   display: flex;
   align-items: center;
   box-sizing: border-box;
@@ -34,12 +34,28 @@
       &-horizontal {
         background: none;
       }
-      .ant-menu-item-selected {
-        background-color: var(--vscode-tab-activeBackground, #282c34);
-      }
-      .ant-menu-item:hover {
-        background-color: var(--vscode-tab-hoverBackground, #323842);
-      }
+      // .ant-menu-item-selected {
+      //   background-color: var(--vscode-tab-activeBackground, #282c34);
+      // }
+      // .ant-menu-item:hover {
+      //   background-color: var(--vscode-tab-hoverBackground, #323842);
+      // }
+    }
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item:hover,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu:hover,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-active,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-active,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-open,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-open,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item-selected,
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu-selected {
+      border-color: transparent;
+      background-color: var(--vscode-list-activeSelectionBackground, #094771);
+      color: #fff;
+    }
+
+    .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-item, .ant-menu-horizontal:not(.ant-menu-dark) > .ant-menu-submenu {
+      padding: 0 20px !important;
     }
   }
 }

--- a/template-packages/leek-center/src/components/layout/Header.tsx
+++ b/template-packages/leek-center/src/components/layout/Header.tsx
@@ -29,7 +29,7 @@ export default function LHeader() {
       <div className={Styles.logo}>韭菜中心</div>
       <Menu
         onClick={handleClick}
-        theme="dark"
+        // theme="dark"
         mode="horizontal"
         selectedKeys={[defaultSelectedKeys]}
       >

--- a/template-packages/leek-center/src/view/data-center/index.tsx
+++ b/template-packages/leek-center/src/view/data-center/index.tsx
@@ -29,7 +29,7 @@ export default function DataCenter({ children }: { children: ReactElement }) {
         }}
       >
         <Menu
-          theme="dark"
+          // theme="dark"
           style={{
             height: 'calc(100vh - 86px)',
           }}


### PR DESCRIPTION
fix: https://github.com/LeekHub/leek-fund/issues/479
可能升级到antd 5 然后监听vscode 主题变化更好

<img width="1439" height="867" alt="企业微信截图_7531ab0e-f4db-4fa4-aaa0-d83e7eba5e5d" src="https://github.com/user-attachments/assets/2c40d44d-a210-4abc-8037-419de09d4b15" />
<img width="1439" height="870" alt="企业微信截图_f4be2d98-d784-4204-a0e4-3afb92c9c769" src="https://github.com/user-attachments/assets/5abdfbf6-8562-4fa1-b614-729be3d2e873" />
<img width="1439" height="870" alt="企业微信截图_d781d2bc-06cc-427a-88f3-87cf9c0f5af4" src="https://github.com/user-attachments/assets/a11549be-7604-4470-ae9b-f01e7882127a" />
