### PR TITLE
feat: 添加今日成本价，用于辅助计算当日盈亏

### DIFF
--- a/src/explorer/stockService.ts
+++ b/src/explorer/stockService.ts
@@ -134,6 +134,7 @@ export default class StockService extends LeekService {
             name: string;
             price: string;
             unitPrice: number;
+            todayUnitPrice: number;
           };
         } = globalState.stockPrice;
 
@@ -159,6 +160,7 @@ export default class StockService extends LeekService {
                 // 表示是持仓股
                 heldData.heldAmount = profitData.amount;
                 heldData.heldPrice = profitData.unitPrice;
+                heldData.todayHeldPrice = profitData.todayUnitPrice;
               }
               stockItem = {
                 code,

--- a/src/shared/leekTreeItem.ts
+++ b/src/shared/leekTreeItem.ts
@@ -47,6 +47,7 @@ export class LeekTreeItem extends TreeItem {
       publishDateTime = '',
       heldAmount = 0,
       heldPrice = 0,
+      todayHeldPrice = 0,
     } = info;
 
     if (_itemType) {
@@ -240,7 +241,7 @@ export class LeekTreeItem extends TreeItem {
       } else if (isFuture) {
         this.tooltip = `【今日行情】${name} ${code}\n 涨跌：${updown}   百分比：${_percent}%\n 最高：${high}   最低：${low}\n 今开：${open}   昨结：${yestclose}\n 成交量：${volume}   成交额：${amount}`;
       } else {
-        this.tooltip = `【今日行情】${labelText}${typeText}${symbolText}\n 涨跌：${updown}   百分比：${_percent}%\n 最高：${high}   最低：${low}\n 今开：${open}   昨收：${yestclose}\n 成交量：${volume}   成交额：${amount}\n ${heldAmount ? `持仓数：${toFixed(heldAmount/heldPrice)}   持仓价：${heldPrice}` : ''
+        this.tooltip = `【今日行情】${labelText}${typeText}${symbolText}\n 涨跌：${updown}   百分比：${_percent}%\n 最高：${high}   最低：${low}\n 今开：${open}   昨收：${yestclose}\n 成交量：${volume}   成交额：${amount}\n ${heldAmount ? `持仓数：${toFixed(heldAmount/heldPrice)}   持仓价：${heldPrice}   今日成本价：${todayHeldPrice}` : ''
           }`;
       }
     } else if (isBinanceItem) {

--- a/src/shared/typed.ts
+++ b/src/shared/typed.ts
@@ -83,6 +83,7 @@ export interface FundInfo {
   publishTime?: string; // 发布时间：时分秒
   heldAmount?: number; // 持仓数
   heldPrice?: number; // 持仓价
+  todayHeldPrice?: number; // 当日持仓价
 }
 
 export const defaultFundInfo: FundInfo = {
@@ -112,6 +113,7 @@ export interface ProfitStatusBarInfo {
 export type HeldData = {
   heldAmount?: number;
   heldPrice?: number;
+  todayHeldPrice?: number;
 };
 
 export type ForexData = {

--- a/src/statusbar/Profit.ts
+++ b/src/statusbar/Profit.ts
@@ -121,7 +121,7 @@ export class ProfitStatusBar {
       stockList.forEach((s) => {
         let tmp = {} as StockInfoType;
         const { id, info } = s;
-        const { high, low, open, yestclose, percent, price, name, heldAmount, heldPrice, code } = info;
+        const { high, low, open, yestclose, percent, price, name, heldAmount, heldPrice, todayHeldPrice, code } = info;
         if (id && open && price) {
           if (!heldAmount || !heldPrice) {
             return false;
@@ -130,7 +130,7 @@ export class ProfitStatusBar {
           // const incomeToday = amount * (Number(price).toFixed(2) - Number(open).toFixed(2));
           const incomeTotal = (heldAmount * (Number(price) - heldPrice)).toFixed(2);
           // fix #399，在昨日收盘价没有的时候使用今日开盘价
-          const incomeToday = (heldAmount * (Number(price) - Number(yestclose || open))).toFixed(2);
+          const incomeToday = (heldAmount * (Number(price) - Number(todayHeldPrice || yestclose || open))).toFixed(2);
           const percentTotal = ((Number(incomeTotal) / (heldPrice * heldAmount)) * 100).toFixed(2);
 
           let incomeTodayCNY = '';

--- a/src/webview/setStockPrice.ts
+++ b/src/webview/setStockPrice.ts
@@ -74,6 +74,7 @@ function stockDataHandler(stockService: StockService) {
       earningPercent: item.info?.earningPercent,
       // unitPrice: item.info?.unitPrice,
       unitPrice: amountObj[item.info?.code]?.unitPrice || 0,
+      todayUnitPrice: amountObj[item.info?.code]?.todayUnitPrice || 0,
       // costUnitPrice: amountObj[item.info?.code]?.unitPrice || 0,
       // priceDate: formatDate(item.info?.time),
       earnings: item.info?.earnings || 0,
@@ -102,6 +103,7 @@ function setStockPriceCfgCb(data: IAmount[]) {
       amount: item.amount || 0,
       price: item.price,
       unitPrice: item.unitPrice,
+      todayUnitPrice: item.todayUnitPrice || 0,
       earnings: item.earnings,
       priceDate: item.priceDate,
     };

--- a/template/stock-price.html
+++ b/template/stock-price.html
@@ -242,6 +242,7 @@
           const amount = item.amount || 0;
           const unitPrice = item.unitPrice || 0;
           const earningPercent = item.earningPercent || 0;
+          const todayUnitPrice = item.todayUnitPrice || 0;
           if (index === 0) {
             priceDate = item.priceDate;
           }
@@ -269,6 +270,13 @@
             '_unit" value="' +
             unitPrice +
             '" /> <span class="unit">元、</span> </div>' +
+            '<div class="unitDiv el-input">' +
+            '今日成本价：<input type="number" class="unitPriceInput el-input__inner" id="' +
+            item.code +
+            '_today_unit" value="' +
+            todayUnitPrice +
+            '" /> <span class="unit">元、</span> </div>' +
+            '</div>' +
             '</div>';
 
           listStr += str;
@@ -467,10 +475,13 @@
           fundList.forEach((item) => {
             let amount = $('#' + item.code).val();
             let unitPrice = $('#' + item.code + '_unit').val();
+            let todayUnitPrice = $('#' + item.code + '_today_unit').val();
             amount = isNaN(Number(amount)) ? 0 : Number(amount);
             unitPrice = isNaN(Number(unitPrice)) ? 0 : Number(unitPrice);
+            todayUnitPrice = isNaN(Number(todayUnitPrice)) ? 0 : Number(todayUnitPrice);
             item.amount = amount; // 持仓金额
             item.unitPrice = unitPrice; // 成本价
+            item.todayUnitPrice = todayUnitPrice; // 今日成本价
             totalMoney += amount; // 持仓金额
             // 收益率
             if (unitPrice !== 0) {
@@ -506,11 +517,13 @@
             Datas.forEach((item) => {
               const amount = ammountObj[item.FCODE].amount;
               const unitPrice = ammountObj[item.FCODE].unitPrice;
+              const todayUnitPrice = ammountObj[item.FCODE].todayUnitPrice;
               const obj = {
                 code: item.FCODE,
                 name: item.SHORTNAME,
                 unitPrice: unitPrice, // 成本价
                 amount: amount, // 持仓金额
+                todayUnitPrice: todayUnitPrice, // 今日成本价
                 earnings: ammountObj[item.FCODE].earnings,
                 price: item.NAV, // 净值
                 priceDate: item.PDATE, // 净值时间


### PR DESCRIPTION

<img width="925" height="40" alt="image" src="https://github.com/user-attachments/assets/d6e8a24e-4043-4b53-85d9-f764d31e27de" />

<img width="386" height="59" alt="image" src="https://github.com/user-attachments/assets/f8e2e512-61e5-49fd-93e7-1ddfcee486a6" />

添加今日成本价（需用户自行计算），用于辅助计算当日有买卖调整场景下的今日盈亏金额计算。