### PR TITLE
fix: 修复集合竞价阶段涨跌百分比为0的bug

### DIFF
--- a/src/explorer/stockService.ts
+++ b/src/explorer/stockService.ts
@@ -374,7 +374,7 @@ export default class StockService extends LeekService {
 
               // 竞价阶段部分开盘和价格为0.00导致显示 -100%
               try {
-                if (Number(open) <= 0) {
+                if (Number(open) <= 0|| Number(price) <= 0) {
                   price = yestclose;
                 }
               } catch (err) {


### PR DESCRIPTION
获取集合竞价阶段的实时价格后，没有对应修复百分比计算，特此修复