### PR TITLE
chore: 兼容以前配置港股股指为大写的用户，在更新配置时转成小写

### DIFF
--- a/src/shared/leekConfig.ts
+++ b/src/shared/leekConfig.ts
@@ -36,7 +36,9 @@ export class BaseConfig {
     const sourceCfg = config.get(cfgKey, []);
     const newCfg = sourceCfg.filter((item) => item !== code);
     if (sourceCfg.length === newCfg.length) {
-      window.showInformationMessage(`删除期货不成功。请 [点击此处](https://github.com/LeekHub/leek-fund/issues/281) 查看期货相关问题`);
+      window.showInformationMessage(
+        `删除期货不成功。请 [点击此处](https://github.com/LeekHub/leek-fund/issues/281) 查看期货相关问题`
+      );
     }
     return config.update(cfgKey, newCfg, true);
   }
@@ -83,11 +85,13 @@ export class LeekFundConfig extends BaseConfig {
     };
 
     if (removedFundList.length) {
-      window.showInformationMessage('删除分组会清空基金数据无法恢复，请确认！！', '好的', '取消').then((res) => {
-        if (res === '好的') {
-          removeFundGroup();
-        }
-      });
+      window
+        .showInformationMessage('删除分组会清空基金数据无法恢复，请确认！！', '好的', '取消')
+        .then((res) => {
+          if (res === '好的') {
+            removeFundGroup();
+          }
+        });
     } else {
       removeFundGroup();
     }
@@ -153,7 +157,13 @@ export class LeekFundConfig extends BaseConfig {
     const config = workspace.getConfiguration();
     const origin: string[] = config.get(cfgKey, []);
     let codes = typeof list === 'string' ? list.split(',') : list;
-    let newCodes = uniq(compact(flattenDeep(origin).concat(codes)));
+    let newCodes = uniq(compact(flattenDeep(origin).concat(codes))) as string[];
+    newCodes = newCodes.map((code: string) => {
+      if (code.startsWith('hk')) {
+        return code.toLowerCase();
+      }
+      return code;
+    });
     config.update(cfgKey, newCodes, true).then(() => {
       window.showInformationMessage(`Stock Successfully add.`);
       if (cb && typeof cb === 'function') {


### PR DESCRIPTION
3.18.1版本已经可以使用户正确获取港股股指了，但是还有一些老用户配置的是大写代码，使得用户删除股指时会提示无法删除，故在配置文件有更新时进行小写转换。
这个解决方案是否采用？