### PR TITLE
fix: 修复某些期货价格不是最新的bug

### DIFF
--- a/src/explorer/stockService.ts
+++ b/src/explorer/stockService.ts
@@ -417,7 +417,7 @@ export default class StockService extends LeekService {
               // '5', '2', '2022-05-04', 'WTI纽约原油2206', '28346"']
               // 当前价格
               let price = params[0];
-              if (price !== params[2] && price !== params[3]) {
+              if (Number(price) > Number(params[3]) || Number(price) < Number(params[2])) {
                 // 价格异常时，取买一价
                 // var hq_str_hf_SI="66.149,,66.100,66.115,66.650,63.725,18:26:14,63.323,63.795,0,6,3,2025-12-17,纽约白银,0";
                 price = params[2];


### PR DESCRIPTION
<img width="779" height="85" alt="image" src="https://github.com/user-attachments/assets/3e70a8b3-5678-4999-9960-705fd1cb4011" />
对比了下，买价卖价和期货交易软件是同步的，但是最新价不对，做个判断选择。