### PR TITLE
feat(ai-config): 移除股票窗口设置AI分析复权日长度，相关配置迁移至AI配置页面

### DIFF
--- a/src/explorer/stockProvider.ts
+++ b/src/explorer/stockProvider.ts
@@ -2,7 +2,7 @@ import { Event, EventEmitter, TreeDataProvider, TreeItem, TreeItemCollapsibleSta
 // import { compact, flattenDeep, uniq } from 'lodash';
 import globalState from '../globalState';
 import { LeekTreeItem } from '../shared/leekTreeItem';
-import { defaultFundInfo, SortType, StockCategory, getAiHistoryRangeLabel } from '../shared/typed';
+import { defaultFundInfo, SortType, StockCategory } from '../shared/typed';
 import { LeekFundConfig } from '../shared/leekConfig';
 import StockService from './stockService';
 
@@ -73,21 +73,6 @@ export class StockProvider implements TreeDataProvider<LeekTreeItem> {
     if (!element.isCategory) {
       return element;
     } else {
-      if (element.id === 'aiHistoryRange') {
-        // 顶部单选项入口：A股AI分析历史长度
-        const range = LeekFundConfig.getConfig('leek-fund.aiStockHistoryRange', '3m');
-        const currentLabel = getAiHistoryRangeLabel(range);
-        return {
-          id: element.id,
-          label: `设置A股AI分析历史复权日线数据，当前：${currentLabel}`,
-          collapsibleState: TreeItemCollapsibleState.None,
-          command: {
-            title: '设置A股AI分析历史复权日线数据',
-            command: 'leek-fund.setAiStockHistoryRange',
-          },
-          contextValue: 'aiHistoryRange',
-        } as TreeItem;
-      }
       return {
         id: element.id,
         label: element.info.name,
@@ -109,15 +94,6 @@ export class StockProvider implements TreeDataProvider<LeekTreeItem> {
 
   getRootNodes(): LeekTreeItem[] {
     const nodes = [
-      // 顶部设置入口：A股AI分析历史长度
-      new LeekTreeItem(
-        Object.assign({ contextValue: 'aiHistoryRange' }, defaultFundInfo, {
-          id: 'aiHistoryRange',
-          name: 'A股AI分析历史长度',
-        }),
-        undefined,
-        true
-      ),
       new LeekTreeItem(
         Object.assign({ contextValue: 'category' }, defaultFundInfo, {
           id: StockCategory.A,

--- a/src/webview/ai-config.ts
+++ b/src/webview/ai-config.ts
@@ -6,6 +6,7 @@ type AiConfig = {
   apiKey: string;
   baseUrl: string;
   model: string;
+  aiStockHistoryRange: string;
 };
 
 export class AiConfigView {
@@ -22,20 +23,28 @@ export class AiConfigView {
   }
 
   private getAiConfig(): AiConfig {
-    const cfgKey = 'leek-fund.aiConfig';
     const config = workspace.getConfiguration();
-    const result = config.get(cfgKey, {
+    const aiConfig = config.get('leek-fund.aiConfig', {
       apiKey: '',
       baseUrl: '',
       model: '',
     });
-    return result;
+    const aiStockHistoryRange = config.get('leek-fund.aiStockHistoryRange', '3m');
+    
+    return {
+      ...aiConfig,
+      aiStockHistoryRange,
+    };
   }
 
   private updateAiConfig(aiConfig: AiConfig) {
-    const cfgKey = 'leek-fund.aiConfig';
     const config = workspace.getConfiguration();
-    config.update(cfgKey, aiConfig, true).then(
+    const { aiStockHistoryRange, ...restConfig } = aiConfig;
+    
+    Promise.all([
+      config.update('leek-fund.aiConfig', restConfig, true),
+      config.update('leek-fund.aiStockHistoryRange', aiStockHistoryRange, true),
+    ]).then(
       () => {
         window.showInformationMessage('AI 配置已更新');
         if (this.panel) {

--- a/template-packages/leek-center/src/view/data-center/ai-config/index.tsx
+++ b/template-packages/leek-center/src/view/data-center/ai-config/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Card, Form, Input, Button, message } from 'antd';
+import { Card, Form, Input, Button, message, Select } from 'antd';
 import { postMessage } from '@/utils/common';
 import './style.less';
 
@@ -18,6 +18,7 @@ const AIConfig: React.FC = () => {
           apiKey: msg.data.apiKey || '',
           baseUrl: msg.data.baseUrl || '',
           model: msg.data.model || '',
+          aiStockHistoryRange: msg.data.aiStockHistoryRange || '3m',
         });
       }
       if (msg.command === 'saveSuccess') {
@@ -71,6 +72,21 @@ const AIConfig: React.FC = () => {
             rules={[{ required: true, message: '请输入模型名称' }]}
           >
             <Input placeholder="例如：gpt-4o-mini 或 deepseek-chat 等" />
+          </Form.Item>
+
+          <Form.Item
+            label="A股AI分析历史长度"
+            name="aiStockHistoryRange"
+            rules={[{ required: true, message: '请选择历史长度' }]}
+            extra="选择用于AI分析的复权日线数据历史长度"
+          >
+            <Select placeholder="请选择历史长度">
+              <Select.Option value="1y">1年</Select.Option>
+              <Select.Option value="6m">6个月</Select.Option>
+              <Select.Option value="3m">3个月</Select.Option>
+              <Select.Option value="1m">1个月</Select.Option>
+              <Select.Option value="1w">1周</Select.Option>
+            </Select>
           </Form.Item>
 
           <Form.Item className="actions">

--- a/template-packages/leek-center/src/view/data-center/ai-config/style.less
+++ b/template-packages/leek-center/src/view/data-center/ai-config/style.less
@@ -32,25 +32,38 @@
     justify-content: flex-end;
     margin-bottom: 0;
   }
+}
 
-  // VS Code Theme Adaptation
-  :global {
-    .ant-form-item-label > label {
-      color: var(--vscode-foreground);
-    }
-    
-    .ant-input {
-      background-color: var(--vscode-input-background);
-      color: var(--vscode-input-foreground);
-      border-color: var(--vscode-input-border, #d9d9d9);
-      
-      &::placeholder {
-        color: var(--vscode-input-placeholderForeground);
+body {
+  .ant-select-selector {
+    background-color: var(--vscode-input-background) !important;
+    color: var(--vscode-input-foreground) !important;
+    border-color: var(--vscode-input-border, #d9d9d9) !important;
+  }
+
+  .ant-select-selection-placeholder {
+    color: var(--vscode-input-placeholderForeground) !important;
+  }
+
+  .ant-select-arrow {
+    color: var(--vscode-foreground) !important;
+  }
+
+  .ant-select-dropdown {
+    background-color: var(--vscode-editorWidget-background) !important;
+    border-color: var(--vscode-editorWidget-border, #d9d9d9) !important;
+
+    .ant-select-item {
+      color: var(--vscode-foreground) !important;
+
+      &:hover {
+        background-color: var(--vscode-list-hoverBackground) !important;
       }
-    }
-    
-    .ant-input-password-icon {
-      color: var(--vscode-foreground);
+
+      &.ant-select-item-option-selected {
+        background-color: var(--vscode-list-activeSelectionBackground) !important;
+        color: var(--vscode-list-activeSelectionForeground) !important;
+      }
     }
   }
 }

--- a/template-packages/leek-center/src/vscode-theme.less
+++ b/template-packages/leek-center/src/vscode-theme.less
@@ -149,6 +149,44 @@
 );
 @input-bg: var(--vscode-input-background, #1d1f23);
 
+@select-dropdown-bg: var(--vscode-editorWidget-background, #1d1f23);
+@select-item-hover-bg: var(--vscode-list-hoverBackground, #2a2d32);
+@select-item-active-bg: var(--vscode-list-activeSelectionBackground, #37373d);
+@select-item-active-color: var(--vscode-list-activeSelectionForeground, #ffffff);
+@select-arrow-color: var(--vscode-foreground, #cccccc);
+@select-placeholder-color: var(--vscode-input-placeholderForeground, rgba(204, 204, 204, 0.5));
+
+.ant-select-selector {
+  background-color: @input-bg !important;
+  color: @input-color !important;
+  border-color: var(--vscode-input-border, #3a3d41) !important;
+}
+
+.ant-select-selection-placeholder {
+  color: @select-placeholder-color !important;
+}
+
+.ant-select-arrow {
+  color: @select-arrow-color !important;
+}
+
+.ant-select-dropdown {
+  background-color: @select-dropdown-bg !important;
+
+  .ant-select-item {
+    color: @text-color !important;
+
+    &:hover {
+      background-color: @select-item-hover-bg !important;
+    }
+
+    &.ant-select-item-option-selected {
+      background-color: @select-item-active-bg !important;
+      color: @select-item-active-color !important;
+    }
+  }
+}
+
 @message-notice-content-bg: var(--vscode-titleBar-activeBackground, #282c34);
 
 @descriptions-bg: var(--vscode-list-activeSelectionBackground, #2c313a);


### PR DESCRIPTION
把ai分析历史复权日长度修改到AI配置页面：<img width="2244" height="1646" alt="image" src="https://github.com/user-attachments/assets/b807ccbf-b126-43f2-8886-ba66fad5f0fc" />
